### PR TITLE
Kill useless and harmful usleep()

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -251,8 +251,6 @@ void file_start(int fd, int argc, char** argv) {
     goto error;
   }
 
-  usleep(200000);
-
   struct timespec time1;
   clock_gettime(CLOCK_MONOTONIC_RAW, &time1);
 


### PR DESCRIPTION
This sleep was causing stale data to accumulate in the USB device. Generally a USB audio device will start sampling on snd_pcm_prepare(). Depending on how it deals with buffer overruns, it may accumulate stale data if we start reading from the buffer too late afterwards.